### PR TITLE
Change note tile rule

### DIFF
--- a/autoload/unite/todo.vim
+++ b/autoload/unite/todo.vim
@@ -91,7 +91,7 @@ function! unite#todo#add(title_list)
     for i in range(0, size-1)
       let title = unite#todo#trim(a:title_list[i])
       if !empty(title)
-        let todo = unite#todo#new(localtime().'_'.i, title)
+        let todo = unite#todo#new(localtime().'_'.i.'_'.s:esctitle(title), title)
         call unite#todo#update(insert(unite#todo#all(), todo))
         call add(added, todo)
       endif
@@ -102,6 +102,16 @@ endfunction
 
 function! unite#todo#trim(str)
   return substitute(a:str, '^\s\+\|\s\+$', '', 'g')
+endfunction
+
+function! s:esctitle(str)
+  let l:todo_title_pattern = "[ /\\'\"]"
+  let str = a:str
+  " let str = tolower(str)
+  let str = substitute(str, l:todo_title_pattern, '-', 'g')
+  let str = substitute(str, '\(--\)\+', '-', 'g')
+  let str = substitute(str, '\(^-\|-$\)', '', 'g')
+  return str
 endfunction
 
 function! unite#todo#rename(todo)

--- a/autoload/unite/todo.vim
+++ b/autoload/unite/todo.vim
@@ -148,7 +148,7 @@ function! unite#todo#toggle(todo)
 endfunction
 
 function! unite#todo#open(todo)
-  execute ':edit ' . a:todo.note
+  execute ':edit ' . fnameescape(a:todo.note)
 endfunction
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
# 変更内容

idを日時から日時＋title(正規化)に変更。
# 理由
- idでnoteファイル名が作成される。
- noteファイルをgrepした時に日時のみだとどのタスクのnoteかわからないため。
# 特記事項

タスク作成後にedit titleした時などは、noteファイル名は作成時のままとする。
（ファイルリネーム等はあまりしたくないため、制限事項とする。)
